### PR TITLE
meta header fix and dynamicifcation

### DIFF
--- a/themes/drone/layouts/partials/header.html
+++ b/themes/drone/layouts/partials/header.html
@@ -12,12 +12,14 @@
 	<link rel="stylesheet" href="/css/style.css">
 {{ if .Params.twitter }}
 	<meta name="twitter:card" content="summary_large_image"/>
-	<meta name="twitter:image:src" content="{{ .Site.BaseUrl }}{{ .Params.twitter.image }}"/>
+  {{ if .Params.twitter.image }}
+	<meta name="twitter:image:src" content="{{ .Site.BaseURL }}{{ .Params.twitter.image }}"/>
+  {{ end }}
 	<meta name="twitter:title" content="{{ .Title }}"/>
 	<meta name="twitter:description" content="{{ .Summary }}"/>
 	<meta name="twitter:site" content="@droneio"/>
 	<meta name="twitter:domain" content="https://twitter.com/droneio"/>
-	<meta name="twitter:creator" content="@bradrydzewski"/>
+	<meta name="twitter:creator" content="{{ .Params.twitter.author }}"/>
 {{ end }}
 
 </head>


### PR DESCRIPTION
`.Site.BaseUrl` was throwing a warning due to an invalid variable, so I am assuming Hugo changed this to `.Site.BaseURL` at some point (https://gohugo.io/templates/variables/#site-variables:2b8b8ac4006be88c769f5e3fd99b009a).

Also un-hardcoded the twitter:creator meta tag, and made the twitter:image only render if the Markdown includes it.
