### PR TITLE
Adjustments to the top-level links.

### DIFF
--- a/themes/drone/layouts/partials/footer.html
+++ b/themes/drone/layouts/partials/footer.html
@@ -4,8 +4,10 @@
 					<div class="pure-menu pure-menu-horizontal pure-menu-open">
 						<ul>
 							<li><a href="https://github.com/drone/">GitHub</a></li>
+							<li><a href="http://readme.drone.io/">Documentation</a></li>
 							<li><a href="https://twitter.com/droneio/">Twitter</a></li>
 							<li><a href="https://gitter.im/drone/drone">Gitter</a></li>
+							<li><a href="https://discuss.drone.io/">Discussion</a></li>
 						</ul>
 					</div>
 				</div>

--- a/themes/drone/layouts/partials/header.html
+++ b/themes/drone/layouts/partials/header.html
@@ -38,7 +38,10 @@
 							<a class="pure-button" href="https://github.com/drone/drone">GitHub</a>
 						</li>
 						<li class="nav-item">
-							<a class="pure-button" href="https://twitter.com/droneio">Twitter</a>
+							<a class="pure-button" href="http://readme.drone.io/">Documentation</a>
+						</li>
+						<li class="nav-item">
+							<a class="pure-button" href="http://readme.drone.io/community/overview/">Community</a>
 						</li>
 					</ul>
 				</nav>


### PR DESCRIPTION
This is a slight change in what top-level links are shown on the blog. Here is the currently deployed link selection:

![image](https://cloud.githubusercontent.com/assets/75556/12407848/d7dd708e-be0f-11e5-9ebb-652c34ccf68b.png)

These are certainly two useful links to have. Things have grown a bit, though. This PR proposes the following:

![image](https://cloud.githubusercontent.com/assets/75556/12407864/f042b31e-be0f-11e5-9cbf-8bed2bdae5ed.png)

Our ideal case scenario with the blog is someone reading an article then deciding to check Drone out in more detail. Three of the biggest criteria in evaluating a piece of software is looking at how it is developed and built, skimming through the documentation, and checking out what kind of community it has. 

I've also "expanded" the same three links in the footer, directly linking Twitter/Gitter/Discussion in place of the collapse "Community" link since I figured it'd be of questionable use to repeat the current three (which are still visible if you scroll).
