### PR TITLE
Adding RSS link to HTML head.

### DIFF
--- a/themes/drone/layouts/partials/header.html
+++ b/themes/drone/layouts/partials/header.html
@@ -5,6 +5,10 @@
 	<title>{{ .Title }} &middot; Drone</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta name="description" content="{{ .Description }}">
+{{ if .RSSlink }}
+    <link href="{{ .RSSlink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
+    <link href="{{ .RSSlink }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
+{{ end }}
 	<link id="favicon" rel="shortcut icon" href="/favicon.ico" />
 
 	<link rel="stylesheet" href="http://yui.yahooapis.com/pure/0.5.0/pure-min.css">


### PR DESCRIPTION
Fairly mundane addition to the `<head>` section to add a link to our RSS feed: http://gohugo.io/templates/rss/#referencing-your-rss-feed-in-head

Results in no visible change. This is mostly for certain browsers or search engines.
